### PR TITLE
Pause improvements

### DIFF
--- a/org/flixel/FlxG.as
+++ b/org/flixel/FlxG.as
@@ -211,6 +211,20 @@ package org.flixel
 		}
 		
 		/**
+		 * the pause overlay, normally FlxGame.pause
+		 */
+		static public function get pauseState() {
+			return _game.pause;
+		} 
+		/*
+		 * @private
+		 */
+		static public function set pauseState(State:FlxGroup) {
+			_game.pause = State;
+		}
+		
+		
+		/**
 		 * Set <code>showBounds</code> to true to display the bounding boxes of the in-game objects.
 		 */
 		static public function get showBounds():Boolean

--- a/org/flixel/FlxGame.as
+++ b/org/flixel/FlxGame.as
@@ -240,6 +240,7 @@ package org.flixel
 		 */
 		protected function onFocusLost(event:Event=null):void
 		{
+			stage.frameRate = _frameratePaused;
 			FlxG.pause = true;
 		}
 		
@@ -266,7 +267,6 @@ package org.flixel
 			}
 			flash.ui.Mouse.show();
 			_paused = true;
-			stage.frameRate = _frameratePaused;
 		}
 		
 		/**


### PR DESCRIPTION
Hi Adam,

Two simple improvements to make pause more useful
- Pausing the game manually does not reduce framerate until focus is lost.
- <code>FlxG.pauseState</code> adedd, provides a reference to <code>FlxGame.pause</code>, as there doesn't seem to be an easy way to access this from within FlxState

If I'm missing something that I should have considered, please let me know!

Brett Taylor
