### PR TITLE
AutoDestroy parameter was never used on loadEmbedded and loadStream

### DIFF
--- a/org/flixel/FlxSound.as
+++ b/org/flixel/FlxSound.as
@@ -257,6 +257,7 @@ package org.flixel
 			_sound = new EmbeddedSound();
 			//NOTE: can't pull ID3 info from embedded sound currently
 			_looped = Looped;
+			autoDestroy = AutoDestroy;
 			updateTransform();
 			exists = true;
 			return this;
@@ -279,6 +280,7 @@ package org.flixel
 			_sound.addEventListener(Event.ID3, gotID3);
 			_sound.load(new URLRequest(SoundURL));
 			_looped = Looped;
+			autoDestroy = AutoDestroy;
 			updateTransform();
 			exists = true;
 			return this;


### PR DESCRIPTION
AutoDestroy parameter was never used on loadEmbedded and loadStream.
Which led to a huge memory leak when using these functions.
