### PR TITLE
Fix to issue #193

### DIFF
--- a/org/flixel/system/FlxPreloader.as
+++ b/org/flixel/system/FlxPreloader.as
@@ -133,7 +133,8 @@ package org.flixel.system
 		
 		private function goToMyURL(event:MouseEvent=null):void
 		{
-			navigateToURL(new URLRequest("http://"+myURL));
+			var prefix:String = myURL.match(/^https?:/) ? "" : "http://";
+			navigateToURL(new URLRequest(prefix+myURL));
 		}
 		
 		private function onEnterFrame(event:Event):void


### PR DESCRIPTION
The Preloader class can now go to urls with http:// or https:// without failing.
