### PR TITLE
Fix for issue #191

### DIFF
--- a/org/flixel/FlxU.as
+++ b/org/flixel/FlxU.as
@@ -66,7 +66,7 @@ package org.flixel
 		 */
 		static public function round(Value:Number):Number
 		{
-			var number:Number = int(Value+((Value>0)?0.5:-0.5));
+			var number:Number = int(Value+0.5);
 			return (Value>0)?(number):((number!=Value)?(number-1):(number));
 		}
 		


### PR DESCRIPTION
Fixed Issue #191 - FlxU.round() giving incorrect results for negative numbers.
https://github.com/AdamAtomic/flixel/issues/191
