### PR TITLE
Suggested fix for Issue #206

### DIFF
--- a/org/flixel/FlxButton.as
+++ b/org/flixel/FlxButton.as
@@ -132,7 +132,7 @@ package org.flixel
 		override public function destroy():void
 		{
 			if(FlxG.stage != null)
-				FlxG.stage.removeEventListener(MouseEvent.MOUSE_UP, onMouseUp);
+				FlxG.stage.removeEventListener(MouseEvent.MOUSE_UP, handleMouseUp);
 			if(label != null)
 			{
 				label.destroy();
@@ -166,7 +166,7 @@ package org.flixel
 			{
 				if(FlxG.stage != null)
 				{
-					FlxG.stage.addEventListener(MouseEvent.MOUSE_UP, onMouseUp);
+					FlxG.stage.addEventListener(MouseEvent.MOUSE_UP, handleMouseUp);
 					_initialized = true;
 				}
 			}
@@ -342,7 +342,7 @@ package org.flixel
 		/**
 		 * Internal function for handling the actual callback call (for UI thread dependent calls like <code>FlxU.openURL()</code>).
 		 */
-		protected function onMouseUp(event:MouseEvent):void
+		protected function handleMouseUp(event:MouseEvent):void
 		{
 			if(!exists || !visible || !active || (status != PRESSED))
 				return;

--- a/org/flixel/FlxGame.as
+++ b/org/flixel/FlxGame.as
@@ -239,7 +239,7 @@ package org.flixel
 		 * 
 		 * @param	FlashEvent	Flash keyboard event.
 		 */
-		protected function onKeyUp(FlashEvent:KeyboardEvent):void
+		protected function handleKeyUp(FlashEvent:KeyboardEvent):void
 		{
 			if(_debuggerUp && _debugger.watch.editing)
 				return;
@@ -296,7 +296,7 @@ package org.flixel
 		 * 
 		 * @param	FlashEvent	Flash keyboard event.
 		 */
-		protected function onKeyDown(FlashEvent:KeyboardEvent):void
+		protected function handleKeyDown(FlashEvent:KeyboardEvent):void
 		{
 			if(_debuggerUp && _debugger.watch.editing)
 				return;
@@ -331,7 +331,7 @@ package org.flixel
 		 * 
 		 * @param	FlashEvent	Flash mouse event.
 		 */
-		protected function onMouseDown(FlashEvent:MouseEvent):void
+		protected function handleMouseDown(FlashEvent:MouseEvent):void
 		{
 			if(_debuggerUp)
 			{
@@ -370,7 +370,7 @@ package org.flixel
 		 * 
 		 * @param	FlashEvent	Flash mouse event.
 		 */
-		protected function onMouseUp(FlashEvent:MouseEvent):void
+		protected function handleMouseUp(FlashEvent:MouseEvent):void
 		{
 			if((_debuggerUp && _debugger.hasMouse) || _replaying)
 				return;
@@ -382,7 +382,7 @@ package org.flixel
 		 * 
 		 * @param	FlashEvent	Flash mouse event.
 		 */
-		protected function onMouseWheel(FlashEvent:MouseEvent):void
+		protected function handleMouseWheel(FlashEvent:MouseEvent):void
 		{
 			if((_debuggerUp && _debugger.hasMouse) || _replaying)
 				return;
@@ -671,11 +671,11 @@ package org.flixel
             stage.frameRate = _flashFramerate;
 			
 			//Add basic input event listeners and mouse container
-			stage.addEventListener(MouseEvent.MOUSE_DOWN, onMouseDown);
-			stage.addEventListener(MouseEvent.MOUSE_UP, onMouseUp);
-			stage.addEventListener(MouseEvent.MOUSE_WHEEL, onMouseWheel);
-			stage.addEventListener(KeyboardEvent.KEY_DOWN, onKeyDown);
-			stage.addEventListener(KeyboardEvent.KEY_UP, onKeyUp);
+			stage.addEventListener(MouseEvent.MOUSE_DOWN, handleMouseDown);
+			stage.addEventListener(MouseEvent.MOUSE_UP, handleMouseUp);
+			stage.addEventListener(MouseEvent.MOUSE_WHEEL, handleMouseWheel);
+			stage.addEventListener(KeyboardEvent.KEY_DOWN, handleKeyDown);
+			stage.addEventListener(KeyboardEvent.KEY_UP, handleKeyUp);
 			addChild(_mouse);
 			
 			//Let mobile devs opt out of unnecessary overlays.

--- a/org/flixel/system/FlxDebugger.as
+++ b/org/flixel/system/FlxDebugger.as
@@ -116,8 +116,8 @@ package org.flixel.system
 			setLayout(FlxG.DEBUGGER_STANDARD);
 			
 			//Should help with fake mouse focus type behavior
-			addEventListener(MouseEvent.MOUSE_OVER,onMouseOver);
-			addEventListener(MouseEvent.MOUSE_OUT,onMouseOut);
+			addEventListener(MouseEvent.MOUSE_OVER,handleMouseOver);
+			addEventListener(MouseEvent.MOUSE_OUT,handleMouseOut);
 		}
 		
 		/**
@@ -142,8 +142,8 @@ package org.flixel.system
 			vis.destroy();
 			vis = null;
 			
-			removeEventListener(MouseEvent.MOUSE_OVER,onMouseOver);
-			removeEventListener(MouseEvent.MOUSE_OUT,onMouseOut);
+			removeEventListener(MouseEvent.MOUSE_OVER,handleMouseOver);
+			removeEventListener(MouseEvent.MOUSE_OUT,handleMouseOut);
 		}
 		
 		/**
@@ -151,7 +151,7 @@ package org.flixel.system
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseOver(E:MouseEvent=null):void
+		protected function handleMouseOver(E:MouseEvent=null):void
 		{
 			hasMouse = true;
 		}
@@ -161,7 +161,7 @@ package org.flixel.system
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseOut(E:MouseEvent=null):void
+		protected function handleMouseOut(E:MouseEvent=null):void
 		{
 			hasMouse = false;
 		}

--- a/org/flixel/system/FlxWindow.as
+++ b/org/flixel/system/FlxWindow.as
@@ -205,9 +205,9 @@ package org.flixel.system
 				return;
 			removeEventListener(Event.ENTER_FRAME,init);
 			
-			stage.addEventListener(MouseEvent.MOUSE_MOVE,onMouseMove);
-			stage.addEventListener(MouseEvent.MOUSE_DOWN,onMouseDown);
-			stage.addEventListener(MouseEvent.MOUSE_UP,onMouseUp);
+			stage.addEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+			stage.addEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+			stage.addEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
 		}
 		
 		/**
@@ -215,7 +215,7 @@ package org.flixel.system
 		 * 
 		 * @param E		Flash mouse event.
 		 */
-		protected function onMouseMove(E:MouseEvent=null):void
+		protected function handleMouseMove(E:MouseEvent=null):void
 		{
 			if(_dragging) //user is moving the window around
 			{
@@ -246,7 +246,7 @@ package org.flixel.system
 		 * 
 		 * @param E		Flash mouse event.
 		 */
-		protected function onMouseDown(E:MouseEvent=null):void
+		protected function handleMouseDown(E:MouseEvent=null):void
 		{
 			if(_overHeader)
 			{
@@ -267,7 +267,7 @@ package org.flixel.system
 		 * 
 		 * @param E		Flash mouse event.
 		 */
-		protected function onMouseUp(E:MouseEvent=null):void
+		protected function handleMouseUp(E:MouseEvent=null):void
 		{
 			_dragging = false;
 			_resizing = false;

--- a/org/flixel/system/debug/VCR.as
+++ b/org/flixel/system/debug/VCR.as
@@ -169,9 +169,9 @@ package org.flixel.system.debug
 			removeChild(_step);
 			_step = null;
 			
-			parent.removeEventListener(MouseEvent.MOUSE_MOVE,onMouseMove);
-			parent.removeEventListener(MouseEvent.MOUSE_DOWN,onMouseDown);
-			parent.removeEventListener(MouseEvent.MOUSE_UP,onMouseUp);
+			parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+			parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+			parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
 		}
 		
 		/**
@@ -445,9 +445,9 @@ package org.flixel.system.debug
 				return;
 			removeEventListener(Event.ENTER_FRAME,init);
 
-			parent.addEventListener(MouseEvent.MOUSE_MOVE,onMouseMove);
-			parent.addEventListener(MouseEvent.MOUSE_DOWN,onMouseDown);
-			parent.addEventListener(MouseEvent.MOUSE_UP,onMouseUp);
+			parent.addEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+			parent.addEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+			parent.addEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
 		}
 		
 		/**
@@ -455,7 +455,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseMove(E:MouseEvent=null):void
+		protected function handleMouseMove(E:MouseEvent=null):void
 		{
 			if(!checkOver())
 				unpress();
@@ -467,7 +467,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseDown(E:MouseEvent=null):void
+		protected function handleMouseDown(E:MouseEvent=null):void
 		{
 			unpress();
 			if(_overOpen)
@@ -488,7 +488,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseUp(E:MouseEvent=null):void
+		protected function handleMouseUp(E:MouseEvent=null):void
 		{
 			if(_overOpen && _pressingOpen)
 				onOpen();

--- a/org/flixel/system/debug/Vis.as
+++ b/org/flixel/system/debug/Vis.as
@@ -49,9 +49,9 @@ package org.flixel.system.debug
 			removeChild(_bounds);
 			_bounds = null;
 			
-			parent.removeEventListener(MouseEvent.MOUSE_MOVE,onMouseMove);
-			parent.removeEventListener(MouseEvent.MOUSE_DOWN,onMouseDown);
-			parent.removeEventListener(MouseEvent.MOUSE_UP,onMouseUp);
+			parent.removeEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+			parent.removeEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+			parent.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
 		}
 		
 		//***ACTUAL BUTTON BEHAVIORS***//
@@ -77,9 +77,9 @@ package org.flixel.system.debug
 				return;
 			removeEventListener(Event.ENTER_FRAME,init);
 			
-			parent.addEventListener(MouseEvent.MOUSE_MOVE,onMouseMove);
-			parent.addEventListener(MouseEvent.MOUSE_DOWN,onMouseDown);
-			parent.addEventListener(MouseEvent.MOUSE_UP,onMouseUp);
+			parent.addEventListener(MouseEvent.MOUSE_MOVE,handleMouseMove);
+			parent.addEventListener(MouseEvent.MOUSE_DOWN,handleMouseDown);
+			parent.addEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
 		}
 		
 		/**
@@ -87,7 +87,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseMove(E:MouseEvent=null):void
+		protected function handleMouseMove(E:MouseEvent=null):void
 		{
 			if(!checkOver())
 				unpress();
@@ -99,7 +99,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseDown(E:MouseEvent=null):void
+		protected function handleMouseDown(E:MouseEvent=null):void
 		{
 			unpress();
 			if(_overBounds)
@@ -112,7 +112,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	E	Flash mouse event.
 		 */
-		protected function onMouseUp(E:MouseEvent=null):void
+		protected function handleMouseUp(E:MouseEvent=null):void
 		{
 			if(_overBounds && _pressingBounds)
 				onBounds();

--- a/org/flixel/system/debug/WatchEntry.as
+++ b/org/flixel/system/debug/WatchEntry.as
@@ -81,8 +81,8 @@ package org.flixel.system.debug
 			valueDisplay.multiline = false;
 			valueDisplay.selectable = true;
 			valueDisplay.doubleClickEnabled = true;
-			valueDisplay.addEventListener(KeyboardEvent.KEY_UP,onKeyUp);
-			valueDisplay.addEventListener(MouseEvent.MOUSE_UP,onMouseUp);
+			valueDisplay.addEventListener(KeyboardEvent.KEY_UP,handleKeyUp);
+			valueDisplay.addEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
 			valueDisplay.background = false;
 			valueDisplay.backgroundColor = 0xffffff;
 			valueDisplay.defaultTextFormat = _whiteText;
@@ -100,8 +100,8 @@ package org.flixel.system.debug
 			nameDisplay = null;
 			field = null;
 			custom = null;
-			valueDisplay.removeEventListener(MouseEvent.MOUSE_UP,onMouseUp);
-			valueDisplay.removeEventListener(KeyboardEvent.KEY_UP,onKeyUp);
+			valueDisplay.removeEventListener(MouseEvent.MOUSE_UP,handleMouseUp);
+			valueDisplay.removeEventListener(KeyboardEvent.KEY_UP,handleKeyUp);
 			valueDisplay = null;
 		}
 		
@@ -148,7 +148,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	FlashEvent	Flash mouse event.
 		 */
-		public function onMouseUp(FlashEvent:MouseEvent):void
+		public function handleMouseUp(FlashEvent:MouseEvent):void
 		{
 			editing = true;
 			oldValue = object[field];
@@ -164,7 +164,7 @@ package org.flixel.system.debug
 		 * 
 		 * @param	FlashEvent	Flash keyboard event.
 		 */
-		public function onKeyUp(FlashEvent:KeyboardEvent):void
+		public function handleKeyUp(FlashEvent:KeyboardEvent):void
 		{
 			if((FlashEvent.keyCode == 13) || (FlashEvent.keyCode == 9) || (FlashEvent.keyCode == 27)) //enter or tab or escape
 			{


### PR DESCRIPTION
Using the following function names results in Migration Issue warning
from Flash Professional:
onKeyUp, onKeyPress, onKeyDown, onMouseDown, onMouseUp, onMouseMove
See Issue #206 https://github.com/AdamAtomic/flixel/issues/206

Replaced all occurances of those names with:
handleKeyUp, handleKeyPress, etc.
(I hope I got them all!)
