### PR TITLE
FlxSprite#overlap and FlxSprite#overlapAt only check the first element of a FlxGroup

### DIFF
--- a/org/flixel/FlxObject.as
+++ b/org/flixel/FlxObject.as
@@ -687,6 +687,7 @@ package org.flixel
 				var results:Boolean = false;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					if(overlaps(members[i++],InScreenSpace,Camera))
@@ -738,6 +739,7 @@ package org.flixel
 				var basic:FlxBasic;
 				var i:uint = 0;
 				var members:Array = (ObjectOrGroup as FlxGroup).members;
+				var length:uint = (ObjectOrGroup as FlxGroup).length;
 				while(i < length)
 				{
 					if(overlapsAt(X,Y,members[i++],InScreenSpace,Camera))


### PR DESCRIPTION
It seems the code uses the wrong length variable. The one that is used is always 1, so it will only check the first element of the FlxGroup. This patch uses the length attribute of the FlxGroup object and fixes the behaviour.
